### PR TITLE
RA-923:Manage Extension page UI

### DIFF
--- a/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceImplTest.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 @SkipBaseSetup
 public class AppFrameworkServiceImplTest extends BaseModuleContextSensitiveTest {
 
+
     @Autowired
     private AppFrameworkService appFrameworkService;
 


### PR DESCRIPTION
For this https://issues.openmrs.org/browse/RA-923 ticket,i have added getExtensions() in the service so as it is used for calling the available extensions within the reference application.To use this method,changes have to be made in the reference application