### PR TITLE
Re-refresh context to fix subsequent test failures

### DIFF
--- a/api/src/test/java/org/openmrs/module/appframework/config/AppFrameworkConfigRuntimeTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/config/AppFrameworkConfigRuntimeTest.java
@@ -38,5 +38,6 @@ public class AppFrameworkConfigRuntimeTest extends BaseModuleContextSensitiveTes
     @After
     public void teardown() {
         runtimeProperties.remove(AppFrameworkConfig.APP_FRAMEWORK_CONFIGURATION_RUNTIME_PROPERTY);
+        new AppFrameworkActivator().contextRefreshed();
     }
 }


### PR DESCRIPTION
**Why**
Tests have been consistently failing in Travis-CI builds because of state changes in non-independent tests. Note that this can cause tests to run fine in isolation (e.g. on a local machine) but fail in the travis build when they are run in a certain order.

For Example see: https://talk.openmrs.org/t/failing-test-by-travis-within-appframe-work/23286

**What Changed**
Re-refreshed the context in `AppFrameworkConfigRuntimeTest` because that seemed to be causing failures when `AppFrameworkServiceImplTest` tests were run later in the build sequence.

**Decisions Made**
I opted to try to patch the issue with minimal impact by maintaining the current testing setup. However, an alternative fix (if this kind of error comes up again) would be to just run every test in isolation configuring maven surefire to **NOT** reuse forks:

```
<plugin>
  <groupId>org.apache.maven.plugins</groupId>
  <artifactId>maven-surefire-plugin</artifactId>
  <version>2.22.1</version>
  <configuration>
    <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
    <forkCount>1</forkCount>
    <reuseForks>false</reuseForks>
  </configuration>
</plugin>
```
The drawback to the above approach is that running tests will take much longer.