### PR TITLE
RA-1766: Expose the checkRequireExpression() method

### DIFF
--- a/api/src/main/java/org/openmrs/module/appframework/domain/Extension.java
+++ b/api/src/main/java/org/openmrs/module/appframework/domain/Extension.java
@@ -10,7 +10,7 @@ import org.openmrs.module.appframework.template.TemplateFactory;
 
 import java.util.Map;
 
-public class Extension implements Comparable<Extension> {
+public class Extension implements Requireable, Comparable<Extension> {
 	
 	@NotEmpty(message = ValidationErrorMessages.EXTENSION_ID_NOT_EMPTY_MESSAGE)
 	@JsonProperty

--- a/api/src/main/java/org/openmrs/module/appframework/domain/Requireable.java
+++ b/api/src/main/java/org/openmrs/module/appframework/domain/Requireable.java
@@ -1,0 +1,13 @@
+package org.openmrs.module.appframework.domain;
+
+import org.openmrs.module.appframework.context.AppContextModel;
+
+/**
+ * An interface for objects which can be required or excluded by evaluating a Javascript expression using {@link org.openmrs.module.appframework.service.AppFrameworkService#checkRequireExpression(Requireable, AppContextModel)}
+ */
+public interface Requireable {
+
+	String getId();
+
+	String getRequire();
+}

--- a/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkService.java
+++ b/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkService.java
@@ -19,6 +19,7 @@ import org.openmrs.module.appframework.context.AppContextModel;
 import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.appframework.domain.AppTemplate;
 import org.openmrs.module.appframework.domain.Extension;
+import org.openmrs.module.appframework.domain.Requireable;
 import org.openmrs.module.appframework.domain.UserApp;
 
 import java.util.List;
@@ -167,4 +168,13 @@ public interface AppFrameworkService extends OpenmrsService {
      */
     void purgeUserApp(UserApp userApp);
 
+	/**
+	 * Checks whether a Requireable object should be included in the current context
+	 *
+	 * @since 2.15.0
+	 * @param candidate the requireable object to check
+	 * @param contextModel the current context to check against
+	 * @return true if the requireable should be included in this context; false otherwise
+	 */
+	boolean checkRequireExpression(Requireable candidate, AppContextModel contextModel);
 }

--- a/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
@@ -47,6 +47,7 @@ import org.openmrs.module.appframework.domain.AppTemplate;
 import org.openmrs.module.appframework.domain.ComponentState;
 import org.openmrs.module.appframework.domain.ComponentType;
 import org.openmrs.module.appframework.domain.Extension;
+import org.openmrs.module.appframework.domain.Requireable;
 import org.openmrs.module.appframework.domain.UserApp;
 import org.openmrs.module.appframework.feature.FeatureToggleProperties;
 import org.openmrs.module.appframework.repository.AllAppDescriptors;
@@ -315,8 +316,8 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 		return extensions;
 	}
 	
-	// making it public is a hack so we can test this directly in the appui module
-	public boolean checkRequireExpression(Extension candidate, AppContextModel contextModel) {
+	@Override
+	public boolean checkRequireExpression(Requireable candidate, AppContextModel contextModel) {
 		try {
 			String requireExpression = candidate.getRequire();
 			if (StringUtils.isBlank(requireExpression)) {
@@ -344,18 +345,19 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 					}
 					catch (Exception ex) {
 						StringBuilder extraInfo = new StringBuilder();
-						extraInfo.append("type:" + e.getValue().getClass().getName());
+						extraInfo.append("type:").append(e.getValue().getClass().getName());
 						if (e.getValue() instanceof Map) {
 							Map<?, ?> map = (Map<?, ?>) e.getValue();
 							extraInfo.append(" properties:");
 							for (Map.Entry entry : map.entrySet()) {
 								extraInfo.append(" ").append(entry.getKey().toString()).append(":")
-								        .append(entry.getValue() == null ? "null" : entry.getValue().getClass().toString());
+										.append(entry.getValue() == null ? "null" : entry.getValue().getClass().toString());
 							}
 						}
 						log.error("Failed to set '" + e.getKey() + "' scope variable (" + extraInfo
-						        + ") while evaluating require check for extension " + candidate.getId(),
-						    ex);
+										+ ") while evaluating require check for " + candidate.getClass().getSimpleName()
+										.toLowerCase() + " " + candidate.getId(),
+								ex);
 						return false;
 					}
 				}


### PR DESCRIPTION
This PR is for partial support of RA-1766, which adds the "require" property from the AppFramework to the registration app. This is done by adding an interface to describe and object that has the "require" property and then exposing the existing `checkRequireExpression()` method through the public API for the `AppFrameworkService`.