### PR TITLE
AF-67: Support OpenMRS 2.5+

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>appframework</artifactId>
-		<version>2.17.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>appframework-api</artifactId>
@@ -23,21 +23,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.openmrs.web</groupId>
-			<artifactId>openmrs-web</artifactId>
-			<type>jar</type>
-		</dependency>
-
-		<dependency>
 			<groupId>org.openmrs.api</groupId>
 			<artifactId>openmrs-api</artifactId>
-			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.openmrs.web</groupId>
-			<artifactId>openmrs-web</artifactId>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -50,13 +37,6 @@
 		</dependency>
 
 		<!-- End OpenMRS core -->
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.openmrs.module</groupId>

--- a/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
@@ -13,7 +13,6 @@
  */
 package org.openmrs.module.appframework.service;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/api/src/test/java/org/openmrs/module/appframework/AppFrameworkActivatorComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/AppFrameworkActivatorComponentTest.java
@@ -1,6 +1,6 @@
 package org.openmrs.module.appframework;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.appframework.config.AppFrameworkConfig;
 import org.openmrs.module.appframework.domain.AppDescriptor;
@@ -10,7 +10,7 @@ import org.openmrs.module.appframework.factory.AppFrameworkFactory;
 import org.openmrs.module.appframework.repository.AllAppDescriptors;
 import org.openmrs.module.appframework.repository.AllAppTemplates;
 import org.openmrs.module.appframework.repository.AllFreeStandingExtensions;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/api/src/test/java/org/openmrs/module/appframework/AppFrameworkActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/AppFrameworkActivatorTest.java
@@ -1,44 +1,32 @@
 package org.openmrs.module.appframework;
 
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
 import org.openmrs.LocationTag;
 import org.openmrs.api.LocationService;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- *
- */
 public class AppFrameworkActivatorTest {
 
     @Test
-    public void testCreatingLocationTagIfItDoesNotExist() throws Exception {
+    public void testCreatingLocationTagIfItDoesNotExist() {
         LocationService locationService = mock(LocationService.class);
-
         new AppFrameworkActivator().setupLoginLocationTag(locationService);
-
-        verify(locationService).saveLocationTag(argThat(new ArgumentMatcher<LocationTag>() {
-            @Override
-            public boolean matches(Object argument) {
-                LocationTag actual = (LocationTag) argument;
-                return actual.getName().equals(AppFrameworkConstants.LOCATION_TAG_SUPPORTS_LOGIN);
-            }
-        }));
+        verify(locationService).saveLocationTag(argThat(actual ->
+                actual.getName().equals(AppFrameworkConstants.LOCATION_TAG_SUPPORTS_LOGIN)
+        ));
     }
 
     @Test
-    public void testCreatingLocationTagDoesNothingIfItAlreadyExist() throws Exception {
+    public void testCreatingLocationTagDoesNothingIfItAlreadyExist() {
         LocationService locationService = mock(LocationService.class);
         when(locationService.getLocationTagByName(AppFrameworkConstants.LOCATION_TAG_SUPPORTS_LOGIN)).thenReturn(new LocationTag());
-
         new AppFrameworkActivator().setupLoginLocationTag(locationService);
-
         verify(locationService, never()).saveLocationTag(any(LocationTag.class));
     }
 

--- a/api/src/test/java/org/openmrs/module/appframework/ContextLoadTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/ContextLoadTest.java
@@ -14,8 +14,8 @@
 
 package org.openmrs.module.appframework;
 
-import org.junit.Test;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.junit.jupiter.api.Test;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.validation.Validator;

--- a/api/src/test/java/org/openmrs/module/appframework/config/AppFrameworkConfigRuntimeTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/config/AppFrameworkConfigRuntimeTest.java
@@ -1,20 +1,20 @@
 package org.openmrs.module.appframework.config;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.appframework.AppFrameworkActivator;
 import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.appframework.domain.Extension;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 public class AppFrameworkConfigRuntimeTest extends BaseModuleContextSensitiveTest {
 
-    @Before
+    @BeforeEach
     public void setup() {
         runtimeProperties.setProperty(AppFrameworkConfig.APP_FRAMEWORK_CONFIGURATION_RUNTIME_PROPERTY, "base  ,hospital");
         new AppFrameworkActivator().contextRefreshed();
@@ -35,7 +35,7 @@ public class AppFrameworkConfigRuntimeTest extends BaseModuleContextSensitiveTes
         assertThat(appFrameworkConfig.isEnabled(extension), is(false));
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         runtimeProperties.remove(AppFrameworkConfig.APP_FRAMEWORK_CONFIGURATION_RUNTIME_PROPERTY);
         new AppFrameworkActivator().contextRefreshed();

--- a/api/src/test/java/org/openmrs/module/appframework/factory/AppConfigurationLoaderFactoryTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/factory/AppConfigurationLoaderFactoryTest.java
@@ -1,13 +1,12 @@
 package org.openmrs.module.appframework.factory;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.appframework.domain.Extension;
 import org.openmrs.module.appframework.repository.AllAppDescriptors;
 import org.openmrs.module.appframework.repository.AllFreeStandingExtensions;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,7 +25,6 @@ public class AppConfigurationLoaderFactoryTest extends BaseModuleContextSensitiv
     AllFreeStandingExtensions allFreeStandingExtensions;
 
     @Test
-    @DirtiesContext
     public void testConfigurationLoad() throws IOException {
 
         List<AppDescriptor> appDescriptors = appConfigurationLoaderFactory.getAppDescriptors();

--- a/api/src/test/java/org/openmrs/module/appframework/repository/AllAppDescriptorsTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/repository/AllAppDescriptorsTest.java
@@ -1,34 +1,27 @@
 package org.openmrs.module.appframework.repository;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.module.appframework.domain.AppDescriptor;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
-import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AllAppDescriptorsTest {
 
     private AllAppDescriptors allAppDescriptors;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         allAppDescriptors = new AllAppDescriptors(Validation.buildDefaultValidatorFactory().getValidator());
         allAppDescriptors.add(new AppDescriptor("app1", "desc1", "label1", "url1", "iconUrl", "tinyIconUrl", 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAddAppFailsWhenAppWithIdExists() {
-        allAppDescriptors.add(new AppDescriptor("app1", "desc2", "label2", "url2", "iconUrl", "tinyIconUrl", 2));
+        assertThrows(IllegalArgumentException.class, () -> allAppDescriptors.add(
+                new AppDescriptor("app1", "desc2", "label2", "url2", "iconUrl", "tinyIconUrl", 2)
+        ));
     }
 }

--- a/api/src/test/java/org/openmrs/module/appframework/repository/AllComponentsStateIT.java
+++ b/api/src/test/java/org/openmrs/module/appframework/repository/AllComponentsStateIT.java
@@ -1,10 +1,9 @@
 package org.openmrs.module.appframework.repository;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.module.appframework.domain.ComponentState;
 import org.openmrs.module.appframework.domain.ComponentType;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.Assert.assertEquals;

--- a/api/src/test/java/org/openmrs/module/appframework/repository/AllComponentsStateTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/repository/AllComponentsStateTest.java
@@ -1,34 +1,30 @@
 package org.openmrs.module.appframework.repository;
 
 import org.hibernate.Criteria;
-import org.openmrs.api.db.hibernate.DbSessionFactory;  
-import org.openmrs.api.db.hibernate.DbSession;  
-import org.hibernate.criterion.Criterion;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.openmrs.api.db.hibernate.DbSession;
+import org.openmrs.api.db.hibernate.DbSessionFactory;
 import org.openmrs.module.appframework.domain.ComponentState;
 import org.openmrs.module.appframework.domain.ComponentType;
 
-import static junit.framework.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AllComponentsStateTest {
 
-    @Mock
     private DbSessionFactory sessionFactory;
-
     private AllComponentsState allComponentsState;
 
     @Before
-    public void setUp() throws Exception {
-        initMocks(this);
+    public void setUp() {
+        sessionFactory = Mockito.mock(DbSessionFactory.class);
         allComponentsState = new AllComponentsState();
         allComponentsState.setSessionFactory(sessionFactory);
     }
@@ -48,10 +44,10 @@ public class AllComponentsStateTest {
         ArgumentCaptor<ComponentState> componentStateArgumentCaptor = ArgumentCaptor.forClass(ComponentState.class);
         verify(mockSession).saveOrUpdate(componentStateArgumentCaptor.capture());
         ComponentState componentState = componentStateArgumentCaptor.getValue();
-        assertEquals(null, componentState.getId());
+        assertNull(componentState.getId());
         assertEquals(componentId, componentState.getComponentId());
         assertEquals(componentType, componentState.getComponentType());
-        assertEquals(true, (boolean) componentState.getEnabled());
+        assertTrue(componentState.getEnabled());
     }
 
     @Test

--- a/api/src/test/java/org/openmrs/module/appframework/service/AdministrativeNotificationServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/service/AdministrativeNotificationServiceImplTest.java
@@ -3,35 +3,26 @@ package org.openmrs.module.appframework.service;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.module.appframework.domain.AdministrativeNotification;
-import org.openmrs.module.appframework.factory.AdministrativeNotificationProducer;
 
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class AdministrativeNotificationServiceImplTest {
 
     private AdministrativeNotificationServiceImpl service;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         service = new AdministrativeNotificationServiceImpl();
     }
 
     @Test
-    public void testGetAdministrativeNotifications() throws Exception {
+    public void testGetAdministrativeNotifications() {
         final AdministrativeNotification notification = new AdministrativeNotification();
-
-        service.setAdministrativeNotificationProducers(Arrays.<AdministrativeNotificationProducer>asList(
-                new AdministrativeNotificationProducer() {
-                    @Override
-                    public List<AdministrativeNotification> generateNotifications() {
-                        return Arrays.asList(notification);
-                    }
-                }));
-
+        service.setAdministrativeNotificationProducers(Arrays.asList(() -> Arrays.asList(notification)));
         List<AdministrativeNotification> notifications = service.getAdministrativeNotifications();
         assertThat(notifications.size(), is(1));
         assertThat(notifications.get(0), is(notification));

--- a/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceImplTest.java
@@ -1,13 +1,13 @@
 package org.openmrs.module.appframework.service;
 
 import org.hibernate.Criteria;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.classic.Session;
 import org.joda.time.LocalDate;
 import org.joda.time.Months;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.db.hibernate.DbSessionFactory;
 import org.openmrs.module.appframework.config.AppFrameworkConfig;
 import org.openmrs.module.appframework.context.AppContextModel;
@@ -66,7 +66,7 @@ public class AppFrameworkServiceImplTest  {
 
     private AppFrameworkServiceImpl service;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
 
         featureToggles.setPropertiesFile(new File(this.getClass().getResource("/" + FeatureToggleProperties.FEATURE_TOGGLE_PROPERTIES_FILE_NAME).getFile()));
@@ -111,7 +111,7 @@ public class AppFrameworkServiceImplTest  {
     	service = new AppFrameworkServiceImpl(null, allAppDescriptors, allFreeStandingExtensions, allComponentsState, null, featureToggles, appFrameworkConfig, null);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         allAppDescriptors.clear();
         allFreeStandingExtensions.clear();

--- a/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceTest.java
@@ -13,24 +13,8 @@
  */
 package org.openmrs.module.appframework.service;
 
-import static junit.framework.Assert.assertNotNull;
-import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.script.Bindings;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Location;
 import org.openmrs.LocationTag;
 import org.openmrs.Person;
@@ -50,13 +34,24 @@ import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.appframework.domain.AppTemplate;
 import org.openmrs.module.appframework.domain.Extension;
 import org.openmrs.module.appframework.domain.UserApp;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
-import org.openmrs.test.Verifies;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
 import org.openmrs.util.RoleConstants;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
 
-@DirtiesContext
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	
 	public static final String LOCATION_UUID1 = "6f42abbc-caac-40ae-a94e-9277ea15c125";
@@ -72,8 +67,9 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	@Autowired
 	private AppFrameworkConfig appFrameworkConfig;
 	
-	@Before
+	@BeforeEach
 	public void setup() throws IOException {
+		authenticate();
 		//trigger loading of the apps
 		new AppFrameworkActivator().contextRefreshed();
 	}
@@ -130,7 +126,6 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	 * @see {@link AppFrameworkService#getAllEnabledExtensions(String)}
 	 */
 	@Test
-	@Verifies(value = "should get all extensions for the specified extensionPointId", method = "getAllEnabledExtensions(String)")
 	public void getAllEnabledExtensions_shouldGetAllExtensionsForTheSpecifiedExtensionPointId() throws Exception {
 		List<Extension> visitExts = appFrameworkService.getAllEnabledExtensions("activeVisitActions");
 		assertEquals(1, visitExts.size());
@@ -145,7 +140,6 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	 * @see {@link AppFrameworkService#getAppsForCurrentUser()}
 	 */
 	@Test
-	@Verifies(value = "should get all enabled apps for the currently logged in user", method = "getAppsForCurrentUser()")
 	public void getAppsForCurrentUser_shouldGetAllEnabledAppsForTheCurrentlyLoggedInUser() throws Exception {
 		User user = setupPrivilegesRolesAndUser("Some Random Privilege");
 		Context.authenticate(user.getUsername(), "Openmr5xy");
@@ -165,7 +159,6 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	 * @see {@link AppFrameworkService#getExtensionsForCurrentUser()}
 	 */
 	@Test
-	@Verifies(value = "should get all enabled extensions for the currently logged in user", method = "getExtensionsForCurrentUser()")
 	public void getExtensionsForCurrentUser_shouldGetAllEnabledExtensionsForTheCurrentlyLoggedInUser() throws Exception {
 		User user = setupPrivilegesRolesAndUser("Some Random Privilege");
 		Context.authenticate(user.getUsername(), "Openmr5xy");
@@ -196,7 +189,6 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	 * @see {@link AppFrameworkService#getAppsForCurrentUser()}
 	 */
 	@Test
-	@Verifies(value = "should return apps with no required privilege if there is no authenticated user", method = "getAppsForCurrentUser()")
 	public void getAppsForCurrentUser_shouldReturnNoAppIfThereIsNoAuthenticatedUser() throws Exception {
 		setupPrivilegesRolesAndUser("Some Random Privilege");
 		if (Context.getAuthenticatedUser() != null)
@@ -211,9 +203,7 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	 * @see {@link AppFrameworkService#getExtensionsForCurrentUser()}
 	 */
 	@Test
-	@Verifies(value = "should return extensions with no required privilege if there is no authenticated user", method = "getExtensionsForCurrentUser()")
-	public void getExtensionsForCurrentUser_shouldReturnExtensionsWithNoRequiredPrivilegeIfThereIsNoAuthenticatedUser()
-	    throws Exception {
+	public void getExtensionsForCurrentUser_shouldReturnExtensionsWithNoRequiredPrivilegeIfThereIsNoAuthenticatedUser() {
 		setupPrivilegesRolesAndUser("Some Random Privilege");
 		if (Context.getAuthenticatedUser() != null)
 			Context.logout();
@@ -227,7 +217,6 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	 * @verifies get all enabled extensions for the logged in user and extensionPointId
 	 */
 	@Test
-	@Verifies(value = "should return no extension if there is no authenticated user", method = "getExtensionsForCurrentUser(String)")
 	public void getExtensionsForCurrentUser_shouldReturnNoExtensionForNoLoggedInUser() throws Exception {
 		Context.logout();
 		List<Extension> userExts = appFrameworkService.getExtensionsForCurrentUser("activeVisitActions");
@@ -239,9 +228,7 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	 * @verifies get all enabled extensions for the logged in user and extensionPointId
 	 */
 	@Test
-	@Verifies(value = "should get all enabled extensions for the logged in user and extension point id", method = "getExtensionsForCurrentUser(String)")
-	public void getExtensionsForCurrentUser_shouldGetAllEnabledExtensionsForTheLoggedInUserAndExtensionPointId()
-	    throws Exception {
+	public void getExtensionsForCurrentUser_shouldGetAllEnabledExtensionsForTheLoggedInUserAndExtensionPointId() {
 		User user = setupPrivilegesRolesAndUser("Some Random Privilege");
 		Context.authenticate(user.getUsername(), "Openmr5xy");
 		assertEquals(user, Context.getAuthenticatedUser());
@@ -256,7 +243,6 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	 * @verifies get all enabled extensions for the logged in user and extensionPointId
 	 */
 	@Test
-	@Verifies(value = "should return no extension for is user does not have privilege", method = "getExtensionsForCurrentUser(String)")
 	public void getExtensionsForCurrentUser_shouldReturnNoExtensionForUserWithoutPrivilege() throws Exception {
 		User user = setupPrivilegesRolesAndUser("Another Random Ext Privilege");
 		Context.authenticate(user.getUsername(), "Openmr5xy");
@@ -271,9 +257,7 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	 * @verifies get all enabled extensions for the logged in user and extensionPointId
 	 */
 	@Test
-	@Verifies(value = "should return just extensions of the id for super user", method = "getExtensionsForCurrentUser(String)")
-	public void getExtensionsForCurrentUser_shouldGetAllEnabledExtensionsForTheSuperUserAndExtensionPointId()
-	    throws Exception {
+	public void getExtensionsForCurrentUser_shouldGetAllEnabledExtensionsForTheSuperUserAndExtensionPointId() {
 		
 		User user = new User();
 		user.setPerson(new Person());
@@ -292,12 +276,7 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 		assertEquals(1, userExts.size());
 		assertEquals("orderXrayExtension", userExts.get(0).getId());
 	}
-	
-	/**
-	 * @see AppFrameworkService#getExtensionsForCurrentUser(String, Bindings)
-	 * @verifies get enabled extensions for the current user whose require property matches the
-	 *           contextModel
-	 */
+
 	@Test
 	public void getExtensionsForCurrentUser_shouldGetEnabledExtensionsForTheCurrentUserByRequireProperty() throws Exception {
 		User user = setupPrivilegesRolesAndUser("Some Random Privilege");
@@ -351,7 +330,6 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	@Test
-	@Verifies(value = "should get all enabled apps", method = "getAllEnabledApps()")
 	public void getAllEnabledApps_shouldGetAllEnabledApps() throws Exception {
 		List<AppDescriptor> apps = appFrameworkService.getAllEnabledApps();
 		assertEquals(4, apps.size());//should include the app with that requires no privilege
@@ -438,7 +416,7 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 		assertEquals(--originalAppDescriptorCount, appFrameworkService.getAllApps().size());
 	}
 	
-	@DirtiesContext
+	
 	@Test
 	public void getLoginLocations_shouldReturnLoginLocationsConfiguredForTheUser() {
 		LocationTag tag = new LocationTag();

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -17,8 +17,14 @@
             </list>
         </property>
         <property name="mappingJarLocations">
-            <ref bean="mappingJarResources"/>
+            <ref bean="mappingJarResources" />
         </property>
+        <property name="packagesToScan">
+            <list>
+                <value>org.openmrs</value>
+            </list>
+        </property>
+        <!--  default properties must be set in the hibernate.default.properties -->
     </bean>
 
 </beans>

--- a/appsfortesting/pom.xml
+++ b/appsfortesting/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>appframework</artifactId>
-        <version>2.17.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>appframework-appsfortesting</artifactId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>appframework</artifactId>
-		<version>2.17.0-SNAPSHOT</version>
+		<version>3.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>appframework-omod</artifactId>

--- a/omod/src/main/java/org/openmrs/module/appframework/rest/AdministrativeNotificationResource.java
+++ b/omod/src/main/java/org/openmrs/module/appframework/rest/AdministrativeNotificationResource.java
@@ -13,13 +13,13 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 import java.util.List;
 
-@Resource(name = RestConstants.VERSION_1 + "/administrativenotification", supportedClass = AdministrativeNotification.class, supportedOpenmrsVersions = {"1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*"})
+@Resource(name = RestConstants.VERSION_1 + "/administrativenotification", supportedClass = AdministrativeNotification.class, supportedOpenmrsVersions = {"1.9.* - 9.9.*"})
 public class AdministrativeNotificationResource implements Listable {
 
     @Override
     public SimpleObject getAll(RequestContext requestContext) throws ResponseException {
         List<AdministrativeNotification> notifications = Context.getService(AdministrativeNotificationService.class).getAdministrativeNotifications();
-        return new NeedsPaging<AdministrativeNotification>(notifications, requestContext).toSimpleObject(null);
+        return new NeedsPaging<>(notifications, requestContext).toSimpleObject(null);
     }
 
     @Override

--- a/omod/src/main/java/org/openmrs/module/appframework/rest/AppResource.java
+++ b/omod/src/main/java/org/openmrs/module/appframework/rest/AppResource.java
@@ -13,7 +13,7 @@ import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingReada
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 
-@Resource(name = RestConstants.VERSION_1 + "/app", supportedClass = AppDescriptor.class, supportedOpenmrsVersions = {"1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*"})
+@Resource(name = RestConstants.VERSION_1 + "/app", supportedClass = AppDescriptor.class, supportedOpenmrsVersions = {"1.9.* - 9.9.*"})
 public class AppResource extends BaseDelegatingReadableResource<AppDescriptor> {
 
     private AppFrameworkService getService() {

--- a/omod/src/main/java/org/openmrs/module/appframework/rest/AppTemplateResource.java
+++ b/omod/src/main/java/org/openmrs/module/appframework/rest/AppTemplateResource.java
@@ -13,7 +13,7 @@ import org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingReada
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 
-@Resource(name = RestConstants.VERSION_1 + "/apptemplate", supportedClass = AppTemplate.class, supportedOpenmrsVersions = {"1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*"})
+@Resource(name = RestConstants.VERSION_1 + "/apptemplate", supportedClass = AppTemplate.class, supportedOpenmrsVersions = {"1.9.* - 9.9.*"})
 public class AppTemplateResource extends BaseDelegatingReadableResource<AppTemplate> {
 
     private AppFrameworkService getService() {

--- a/omod/src/main/java/org/openmrs/module/appframework/rest/ExtensionResource.java
+++ b/omod/src/main/java/org/openmrs/module/appframework/rest/ExtensionResource.java
@@ -25,7 +25,7 @@ import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 
 import java.util.List;
 
-@Resource(name = RestConstants.VERSION_1 + "/extension", supportedClass = Extension.class, supportedOpenmrsVersions = {"1.9.*", "1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*", "2.2.*", "2.3.*", "2.4.*" })
+@Resource(name = RestConstants.VERSION_1 + "/extension", supportedClass = Extension.class, supportedOpenmrsVersions = {"1.9.* - 9.9.*"})
 public class ExtensionResource extends BaseDelegatingReadableResource<Extension> implements Searchable {
 
     private AppFrameworkService getService() {

--- a/omod/src/main/java/org/openmrs/module/appframework/web/AppFrameworkController.java
+++ b/omod/src/main/java/org/openmrs/module/appframework/web/AppFrameworkController.java
@@ -2,10 +2,10 @@ package org.openmrs.module.appframework.web;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openmrs.api.context.Context;
 import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.appframework.domain.Extension;
 import org.openmrs.module.appframework.service.AppFrameworkService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -19,16 +19,14 @@ public class AppFrameworkController {
 
     protected final Log log = LogFactory.getLog(getClass());
 
-    private AppFrameworkService getAppFrameworkService() {
-        return Context.getService(AppFrameworkService.class);
-    }
+    @Autowired
+    AppFrameworkService appFrameworkService;
 
     @RequestMapping(value = "/module/appframework/apps.json", method = RequestMethod.GET)
     @ResponseBody
     public List<AppDescriptor> getApps() {
         log.info("Fetching the list of apps");
 
-        AppFrameworkService appFrameworkService = getAppFrameworkService();
         List<AppDescriptor> appsList = appFrameworkService.getAllApps();
 
         if (log.isDebugEnabled()) log.debug("Fetched all apps : " + appsList);
@@ -41,7 +39,6 @@ public class AppFrameworkController {
     public List<Extension> getExtensions(@RequestParam String extensionPointId) {
         log.info("Fetching the list of extensions");
 
-        AppFrameworkService appFrameworkService = getAppFrameworkService();
         List<Extension> extensions = appFrameworkService.getAllExtensions(extensionPointId);
 
         if (log.isDebugEnabled()) log.debug("Fetched extensions : " + extensions);
@@ -54,7 +51,6 @@ public class AppFrameworkController {
     public List<AppDescriptor> getEnabledApps() {
         log.info("Fetching the list of enabled apps");
 
-        AppFrameworkService appFrameworkService = getAppFrameworkService();
         List<AppDescriptor> appsList = appFrameworkService.getAllEnabledApps();
 
         if (log.isDebugEnabled()) log.debug("Fetched all apps : " + appsList);
@@ -67,7 +63,6 @@ public class AppFrameworkController {
     public List<Extension> getEnabledExtensions(@RequestParam String extensionPointId) {
         log.info("Fetching the list of enabled extensions - extensionPointId : " + extensionPointId);
 
-        AppFrameworkService appFrameworkService = getAppFrameworkService();
         List<Extension> extensions = appFrameworkService.getAllEnabledExtensions(extensionPointId);
 
         if (log.isDebugEnabled()) log.debug("Fetched extensions : " + extensions);
@@ -80,7 +75,6 @@ public class AppFrameworkController {
     public void enableApp(@RequestParam String appId) {
         log.info("Enabling App " + appId);
 
-        AppFrameworkService appFrameworkService = getAppFrameworkService();
         appFrameworkService.enableApp(appId);
     }
 
@@ -89,7 +83,6 @@ public class AppFrameworkController {
     public void disableApp(@RequestParam String appId) {
         log.info("Enabling App " + appId);
 
-        AppFrameworkService appFrameworkService = getAppFrameworkService();
         appFrameworkService.disableApp(appId);
     }
 
@@ -98,7 +91,6 @@ public class AppFrameworkController {
     public void enableExtension(@RequestParam String extensionId) {
         log.info("Enabling Extension " + extensionId);
 
-        AppFrameworkService appFrameworkService = getAppFrameworkService();
         appFrameworkService.enableExtension(extensionId);
     }
 
@@ -107,8 +99,10 @@ public class AppFrameworkController {
     public void disableExtension(@RequestParam String extensionId) {
         log.info("Disabling Extension " + extensionId);
 
-        AppFrameworkService appFrameworkService = getAppFrameworkService();
         appFrameworkService.disableExtension(extensionId);
     }
 
+    public void setAppFrameworkService(AppFrameworkService appFrameworkService) {
+        this.appFrameworkService = appFrameworkService;
+    }
 }

--- a/omod/src/test/java/org/openmrs/module/appframework/rest/AdministrativeNotificationResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/appframework/rest/AdministrativeNotificationResourceTest.java
@@ -1,86 +1,27 @@
 package org.openmrs.module.appframework.rest;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.appframework.domain.AdministrativeNotification;
 import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.servlet.HandlerExecutionChain;
-import org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter;
-import org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class AdministrativeNotificationResourceTest extends BaseModuleWebContextSensitiveTest {
 
-    @Autowired
-    private AnnotationMethodHandlerAdapter handlerAdapter;
-
-    @Autowired
-    private List<DefaultAnnotationHandlerMapping> handlerMappings;
-
-    @Autowired
-    ApplicationContext applicationContext;
-
     @Test
-    public void testGetAll() throws Exception {
-        MockHttpServletRequest request = new MockHttpServletRequest(RequestMethod.GET.toString(),
-                "/rest/v1/administrativenotification");
-        request.addHeader("content-type", "application/json");
-        SimpleObject results = deserialize(handle(request));
-
+    public void testGetAll() {
+        AdministrativeNotificationResource resource = new AdministrativeNotificationResource();
+        SimpleObject results = resource.getAll(new RequestContext());
         assertThat(((List) results.get("results")).size(), is(1));
 
-        Map<String, Object> result = (Map<String, Object>) ((List) results.get("results")).get(0);
-        assertThat((String) result.get("id"), is("id"));
-        assertThat((String) result.get("label"), is("label"));
-        assertThat(((Collection) result.get("actions")).size(), is(1));
+        AdministrativeNotification result = (AdministrativeNotification) ((List) results.get("results")).get(0);
+        assertThat(result.getId(), is("id"));
+        assertThat(result.getLabel(), is("label"));
+        assertThat(result.getActions().size(), is(1));
     }
-
-    /**
-     * Passes the given request to a proper controller.
-     *
-     * @param request
-     * @return
-     * @throws Exception
-     */
-    public MockHttpServletResponse handle(HttpServletRequest request) throws Exception {
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        HandlerExecutionChain handlerExecutionChain = null;
-        for (DefaultAnnotationHandlerMapping handlerMapping : handlerMappings) {
-            handlerExecutionChain = handlerMapping.getHandler(request);
-            if (handlerExecutionChain != null) {
-                break;
-            }
-        }
-        Assert.assertNotNull("The request URI does not exist", handlerExecutionChain);
-
-        handlerAdapter.handle(request, response, handlerExecutionChain.getHandler());
-
-        return response;
-    }
-
-    /**
-     * Deserializes the JSON response.
-     *
-     * @param response
-     * @return
-     * @throws Exception
-     */
-    public SimpleObject deserialize(MockHttpServletResponse response) throws Exception {
-        return new ObjectMapper().readValue(response.getContentAsString(), SimpleObject.class);
-    }
-
 }

--- a/omod/src/test/java/org/openmrs/module/appframework/rest/AppResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/appframework/rest/AppResourceTest.java
@@ -1,26 +1,26 @@
 package org.openmrs.module.appframework.rest;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.appframework.domain.ExtensionPoint;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.openmrs.module.appframework.test.Matchers.hasEntry;
 
 public class AppResourceTest extends BaseModuleWebContextSensitiveTest {
 
     private AppDescriptor app;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         ExtensionPoint extensionPoint1 = new ExtensionPoint("extPtId", "extDescr");
         ExtensionPoint extensionPoint2 = new ExtensionPoint("two", "2d");
         app = new AppDescriptor("id", "description", "label", "http://url", "icon-something", "icon-tiny", 5,
@@ -28,7 +28,7 @@ public class AppResourceTest extends BaseModuleWebContextSensitiveTest {
     }
 
     @Test
-    public void testDefaultRepresentation() throws Exception {
+    public void testDefaultRepresentation() {
         SimpleObject actual = new AppResource().asRepresentation(app, Representation.DEFAULT);
         assertThat(actual, hasEntry("uuid", is("id")));
         assertThat(actual, hasEntry("description", is("description")));

--- a/omod/src/test/java/org/openmrs/module/appframework/rest/AppTemplateResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/appframework/rest/AppTemplateResourceTest.java
@@ -5,22 +5,22 @@ import org.codehaus.jackson.node.TextNode;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.module.appframework.AppFrameworkActivator;
 import org.openmrs.module.appframework.domain.AppTemplate;
 import org.openmrs.module.appframework.service.AppFrameworkService;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.util.OpenmrsUtil;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.openmrs.module.appframework.test.Matchers.hasEntry;
 
 public class AppTemplateResourceTest extends BaseModuleWebContextSensitiveTest {
@@ -28,8 +28,8 @@ public class AppTemplateResourceTest extends BaseModuleWebContextSensitiveTest {
     @Autowired
     private AppFrameworkService service;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         new AppFrameworkActivator().contextRefreshed();
     }
 

--- a/omod/src/test/java/org/openmrs/module/appframework/rest/ExtensionResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/appframework/rest/ExtensionResourceTest.java
@@ -1,24 +1,24 @@
 package org.openmrs.module.appframework.rest;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.module.appframework.domain.Extension;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.openmrs.module.appframework.test.Matchers.hasEntry;
 
 public class ExtensionResourceTest extends BaseModuleWebContextSensitiveTest {
 
     private Extension extension;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("foo", "bar");

--- a/omod/src/test/java/org/openmrs/module/appframework/web/AppFrameworkControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/appframework/web/AppFrameworkControllerTest.java
@@ -1,29 +1,18 @@
 package org.openmrs.module.appframework.web;
 
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.openmrs.api.context.Context;
-import org.openmrs.module.appframework.service.AppFrameworkService;
+import org.mockito.Mockito;
 import org.openmrs.module.appframework.domain.AppDescriptor;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.openmrs.module.appframework.service.AppFrameworkService;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
-@PrepareForTest(Context.class)
-@RunWith(PowerMockRunner.class)
 public class AppFrameworkControllerTest {
-
-    @Mock
-    AppFrameworkService mockAppFrameworkService;
 
     private List<AppDescriptor> getTestAppList() {
         List<AppDescriptor> appDescriptorList = new ArrayList<AppDescriptor>();
@@ -35,12 +24,11 @@ public class AppFrameworkControllerTest {
 
     @Test
     public void testGetAllApps() throws Exception {
-        mockStatic(Context.class);
-        when(Context.getService(AppFrameworkService.class)).thenReturn(mockAppFrameworkService);
+        AppFrameworkService mockAppFrameworkService = Mockito.mock(AppFrameworkService.class);
         when(mockAppFrameworkService.getAllApps()).thenReturn(getTestAppList());
-
-        List<AppDescriptor> appList = new AppFrameworkController().getApps();
-
+        AppFrameworkController appFrameworkController = new AppFrameworkController();
+        appFrameworkController.setAppFrameworkService(mockAppFrameworkService);
+        List<AppDescriptor> appList = appFrameworkController.getApps();
         assertNotNull(appList);
         assertEquals(3, appList.size());
         assertEquals("app1", appList.get(0).getId());

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>appframework</artifactId>
-	<version>2.17.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>App Framework Module</name>
 	<description>Framework supporting the idea of self-contained apps that you can see on your homepage.</description>
@@ -35,8 +35,8 @@
     </modules>
 	
 	<properties>
-		<openMRSVersion>1.9.9</openMRSVersion>
-		<webservicesRestVersion>2.21.0</webservicesRestVersion>
+		<openMRSVersion>2.5.4</openMRSVersion>
+		<webservicesRestVersion>2.29.0</webservicesRestVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <handlebarsVersion>1.1.2</handlebarsVersion>
 	</properties>
@@ -93,26 +93,6 @@
 				<version>${webservicesRestVersion}</version>
 				<scope>provided</scope>
 			</dependency>
-
-        	<dependency>
-            	<groupId>org.powermock</groupId>
-            	<artifactId>powermock-api-mockito</artifactId>
-            	<version>1.5</version>
-            	<scope>test</scope>
-       		</dependency>
-
-        	<dependency>
-           		<groupId>org.powermock</groupId>
-            	<artifactId>powermock-module-junit4</artifactId>
-            	<version>1.4.10</version>
-            	<scope>test</scope>
-            	<exclusions>
-	                <exclusion>
-	                    <groupId>org.javassist</groupId>
-	                    <artifactId>javassist</artifactId>
-	                </exclusion>
-	            </exclusions>
-        	</dependency>
         	
         	<dependency>
 		        <groupId>org.javassist</groupId>
@@ -140,6 +120,21 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<dependencies>
+		<dependency>
+			<groupId>javax.el</groupId>
+			<artifactId>javax.el-api</artifactId>
+			<version>3.0.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.el</artifactId>
+			<version>3.0.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -147,8 +142,8 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<target>1.6</target>
-						<source>1.6</source>
+						<target>8</target>
+						<source>8</source>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
This PR changes the version of OpenMRS that appframework builds against to 2.5.4, and updates all of the unit tests and pom dependencies to be compatible with 2.5.4.  This also ensures the web services run against 2.5.x.  Marking this as a draft PR for discussion, to ensure this makes sense.  I've increased the version to 3.0.0-SNAPSHOT to reflect that this may be incompatible in some ways with the previous version (eg. in terms of use as a dependency) and to allow both branches and release lines to co-exist.

@mogoodrich  / @dkayiwa  - thoughts on this or on alternatives to consider?