### PR TITLE
AF-70: Replacing Nashorn Javascript Engine with GraalVM

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -52,13 +52,6 @@
 		<!-- End OpenMRS core -->
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>appframework-appsfortesting</artifactId>
             <version>${project.parent.version}</version>
@@ -79,6 +72,16 @@
 		<dependency>
 			<groupId>org.graalvm.js</groupId>
 			<artifactId>js-scriptengine</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
 		</dependency>
 
 		<!-- For Testing -->

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -71,8 +71,14 @@
         </dependency>
 
 		<dependency>
-			<groupId>org.graalvm.sdk</groupId>
-			<artifactId>graal-sdk</artifactId>
+			<groupId>org.graalvm.js</groupId>
+			<artifactId>js</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.graalvm.js</groupId>
+			<artifactId>js-scriptengine</artifactId>
 		</dependency>
 
 		<!-- For Testing -->

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -66,7 +66,6 @@
 		<dependency>
 			<groupId>org.graalvm.js</groupId>
 			<artifactId>js</artifactId>
-			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>
@@ -77,11 +76,6 @@
 		<dependency>
 			<groupId>jakarta.xml.bind</groupId>
 			<artifactId>jakarta.xml.bind-api</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.glassfish.jaxb</groupId>
-			<artifactId>jaxb-runtime</artifactId>
 		</dependency>
 
 		<!-- For Testing -->

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -70,6 +70,11 @@
             <artifactId>handlebars</artifactId>
         </dependency>
 
+		<dependency>
+			<groupId>org.graalvm.sdk</groupId>
+			<artifactId>graal-sdk</artifactId>
+		</dependency>
+
 		<!-- For Testing -->
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
@@ -96,7 +96,7 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 		this.allUserApps = allUserApps;
 
 		if (javascriptEngine == null) {
-			javascriptEngine = new jdk.nashorn.api.scripting.NashornScriptEngineFactory().getScriptEngine();
+			javascriptEngine = new ScriptEngineManager().getEngineByName("graal.js");
 			javascriptEngine.setBindings(javascriptEngine.createBindings(), ScriptContext.GLOBAL_SCOPE);
 		}
 

--- a/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
@@ -92,13 +92,10 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 		this.locationService = locationService;
 		this.featureToggles = featureToggles;
 		this.appFrameworkConfig = appFrameworkConfig;
+		System.setProperty("polyglot.js.nashorn-compat", "true");
 		this.javascriptEngine = new ScriptEngineManager().getEngineByName("JavaScript");
 		this.allUserApps = allUserApps;
 
-		if (javascriptEngine == null) {
-			javascriptEngine = new ScriptEngineManager().getEngineByName("graal.js");
-			javascriptEngine.setBindings(javascriptEngine.createBindings(), ScriptContext.GLOBAL_SCOPE);
-		}
 
 		// there is surely a cleaner way to define this utility function in the global scope
 		this.javascriptEngine.eval("function hasMemberWithProperty(list, propName, val) { " + "if (!list) { return false; } "
@@ -346,9 +343,13 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 					} else {
 						bindings.put(e.getKey(), e.getValue());
 					}
-				}
+			}
 
-				javascriptEngine.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
+			for (Map.Entry<String, Object> e : contextModel.entrySet()) {
+				String jsonValue = new ObjectMapper().writeValueAsString(e.getValue());
+				javascriptEngine.eval(e.getKey() + " = " + jsonValue);
+			}
+
 				ObjectMapper jackson = new ObjectMapper();
 				for (Map.Entry<String, Object> e : mapProperties.entrySet()) {
 					try {

--- a/api/src/test/java/org/openmrs/module/appframework/factory/AppConfigurationLoaderFactoryTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/factory/AppConfigurationLoaderFactoryTest.java
@@ -26,7 +26,6 @@ public class AppConfigurationLoaderFactoryTest extends BaseModuleContextSensitiv
     AllFreeStandingExtensions allFreeStandingExtensions;
 
     @Test
-    @DirtiesContext
     public void testConfigurationLoad() throws IOException {
 
         List<AppDescriptor> appDescriptors = appConfigurationLoaderFactory.getAppDescriptors();

--- a/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceImplTest.java
@@ -2,7 +2,7 @@ package org.openmrs.module.appframework.service;
 
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
-import org.hibernate.classic.Session;
+import org.hibernate.Session;
 import org.joda.time.LocalDate;
 import org.joda.time.Months;
 import org.junit.After;

--- a/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/appframework/service/AppFrameworkServiceTest.java
@@ -56,7 +56,6 @@ import org.openmrs.util.RoleConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 
-@DirtiesContext
 public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 	
 	public static final String LOCATION_UUID1 = "6f42abbc-caac-40ae-a94e-9277ea15c125";
@@ -438,7 +437,6 @@ public class AppFrameworkServiceTest extends BaseModuleContextSensitiveTest {
 		assertEquals(--originalAppDescriptorCount, appFrameworkService.getAllApps().size());
 	}
 	
-	@DirtiesContext
 	@Test
 	public void getLoginLocations_shouldReturnLoginLocationsConfiguredForTheUser() {
 		LocationTag tag = new LocationTag();

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -86,7 +86,7 @@
 	        <version>3.18.2-GA</version>
 	        <scope>test</scope>
 	    </dependency>
-		
+
 	</dependencies>
 
 	<build>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -72,7 +72,12 @@
 			<type>pom</type>
 			<scope>test</scope>
 		</dependency>
-		
+
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+		</dependency>
+
 		<!-- End OpenMRS core -->
 
 		<dependency>

--- a/omod/src/test/java/org/openmrs/module/appframework/web/AppFrameworkControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/appframework/web/AppFrameworkControllerTest.java
@@ -1,12 +1,12 @@
 package org.openmrs.module.appframework.web;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.appframework.service.AppFrameworkService;
 import org.openmrs.module.appframework.domain.AppDescriptor;
+import org.openmrs.module.appframework.service.AppFrameworkService;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -20,6 +20,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 @PrepareForTest(Context.class)
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore("jdk.internal.reflect.*")
 public class AppFrameworkControllerTest {
 
     @Mock

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </modules>
 	
 	<properties>
-		<openMRSVersion>1.9.9</openMRSVersion>
+		<openMRSVersion>2.0.0</openMRSVersion>
 		<webservicesRestVersion>2.21.0</webservicesRestVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <handlebarsVersion>1.1.2</handlebarsVersion>
@@ -142,7 +142,6 @@
 				<groupId>org.graalvm.js</groupId>
 				<artifactId>js</artifactId>
 				<version>${graalvm.version}</version>
-				<scope>runtime</scope>
 			</dependency>
 
 			<dependency>
@@ -154,21 +153,17 @@
 			<dependency>
 				<groupId>com.thoughtworks.xstream</groupId>
 				<artifactId>xstream</artifactId>
-				<scope>test</scope>
 				<version>1.4.17</version>
+				<scope>test</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>jakarta.xml.bind</groupId>
 				<artifactId>jakarta.xml.bind-api</artifactId>
+				<scope>test</scope>
 				<version>2.3.2</version>
 			</dependency>
 
-			<dependency>
-				<groupId>org.glassfish.jaxb</groupId>
-				<artifactId>jaxb-runtime</artifactId>
-				<version>4.0.0</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -226,10 +221,6 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.22.1</version>
-					<configuration>
-						<argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
-					</configuration>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -278,9 +269,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>2.22.1</version>
 						<configuration>
-							<argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
 							<argLine>--add-opens java.base/java.lang=ALL-UNNAMED
 								--add-opens java.base/jdk.internal.loader=ALL-UNNAMED
 								--add-opens java.base/java.security=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 		<webservicesRestVersion>2.21.0</webservicesRestVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <handlebarsVersion>1.1.2</handlebarsVersion>
+		<graalvm.version>19.0.0</graalvm.version>
 	</properties>
 
 	<dependencyManagement>
@@ -138,9 +139,16 @@
             </dependency>
 
 			<dependency>
-				<groupId>org.graalvm.sdk</groupId>
-				<artifactId>graal-sdk</artifactId>
-				<version>19.0.0</version>
+				<groupId>org.graalvm.js</groupId>
+				<artifactId>js</artifactId>
+				<version>${graalvm.version}</version>
+				<scope>runtime</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.graalvm.js</groupId>
+				<artifactId>js-scriptengine</artifactId>
+				<version>${graalvm.version}</version>
 			</dependency>
 
 		</dependencies>
@@ -153,8 +161,8 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<target>1.6</target>
-						<source>1.6</source>
+						<target>1.7</target>
+						<source>1.7</source>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,23 @@
 				<version>${graalvm.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>com.thoughtworks.xstream</groupId>
+				<artifactId>xstream</artifactId>
+				<version>1.4.17</version>
+			</dependency>
+
+			<dependency>
+				<groupId>jakarta.xml.bind</groupId>
+				<artifactId>jakarta.xml.bind-api</artifactId>
+				<version>2.3.2</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.glassfish.jaxb</groupId>
+				<artifactId>jaxb-runtime</artifactId>
+				<version>4.0.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -248,6 +265,28 @@
             <url>https://mavenrepo.openmrs.org/snapshots</url>
         </snapshotRepository>
 	</distributionManagement>
+
+	<profiles>
+		<profile>
+			<id>Java 17</id>
+			<activation>
+				<jdk>17</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>2.22.1</version>
+						<configuration>
+							<argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+							<argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 	
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,10 @@
 						<version>2.22.1</version>
 						<configuration>
 							<argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
-							<argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+							<argLine>--add-opens java.base/java.lang=ALL-UNNAMED
+								--add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+								--add-opens java.base/java.security=ALL-UNNAMED
+							</argLine>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,12 @@
                 </exclusions>
             </dependency>
 
+			<dependency>
+				<groupId>org.graalvm.sdk</groupId>
+				<artifactId>graal-sdk</artifactId>
+				<version>19.0.0</version>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
Nashorn Javascript engine is removed in Java 15. So the 2.x reference application fails to run on Java 17. This PR replaces the Nashorn engine with GraalVM which supports both Java 8 and Java 17.

https://issues.openmrs.org/browse/AF-70