### PR TITLE
AF-77: Reduce DB and file reads when getting app components for user

### DIFF
--- a/api/src/main/java/org/openmrs/module/appframework/feature/FeatureToggleProperties.java
+++ b/api/src/main/java/org/openmrs/module/appframework/feature/FeatureToggleProperties.java
@@ -34,6 +34,8 @@ public class FeatureToggleProperties {
 
     private Log log = LogFactory.getLog(getClass());
     private File propertiesFile;
+    private Properties cachedToggles;
+    private long cachedTogglesLastModified = -1;
 
     FeatureToggleProperties() {
         String propertiesFileName = System.getenv(FEATURE_TOGGLE_PROPERTIES_ENV);
@@ -47,6 +49,8 @@ public class FeatureToggleProperties {
     // TODO: find a better way to this--this public setter is just used to override the file in test scripts
     public void setPropertiesFile(File propertiesFile) {
         this.propertiesFile = propertiesFile;
+        this.cachedToggles = null;
+        this.cachedTogglesLastModified = -1;
     }
 
     public boolean isFeatureEnabled(String key) {
@@ -59,19 +63,20 @@ public class FeatureToggleProperties {
         return Collections.unmodifiableMap(toggles);
     }
 
-    private Properties loadToggles() {
-        Properties toggles = new Properties();
-
-        if(propertiesFile.exists()){
-            try {
-                FileInputStream inputStream = new FileInputStream(propertiesFile);
-                toggles.load(inputStream);
-                inputStream.close();
-            } catch (IOException e) {
-                log.error("Problem loading feature_toggles.properties file. Error: ", e);
+    private synchronized Properties loadToggles() {
+        long lastModified = propertiesFile.exists() ? propertiesFile.lastModified() : -1;
+        if (cachedToggles == null || lastModified != cachedTogglesLastModified) {
+            Properties toggles = new Properties();
+            if (propertiesFile.exists()) {
+                try (FileInputStream inputStream = new FileInputStream(propertiesFile)) {
+                    toggles.load(inputStream);
+                } catch (IOException e) {
+                    log.error("Problem loading feature_toggles.properties file. Error: ", e);
+                }
             }
+            cachedToggles = toggles;
+            cachedTogglesLastModified = lastModified;
         }
-
-        return toggles;
+        return cachedToggles;
     }
 }

--- a/api/src/main/java/org/openmrs/module/appframework/feature/FeatureToggleProperties.java
+++ b/api/src/main/java/org/openmrs/module/appframework/feature/FeatureToggleProperties.java
@@ -71,7 +71,8 @@ public class FeatureToggleProperties {
                 try (FileInputStream inputStream = new FileInputStream(propertiesFile)) {
                     toggles.load(inputStream);
                 } catch (IOException e) {
-                    log.error("Problem loading feature_toggles.properties file. Error: ", e);
+                    throw new IllegalStateException("Problem loading feature_toggles.properties file.", e);
+                    
                 }
             }
             cachedToggles = toggles;

--- a/api/src/main/java/org/openmrs/module/appframework/repository/AllComponentsState.java
+++ b/api/src/main/java/org/openmrs/module/appframework/repository/AllComponentsState.java
@@ -3,12 +3,16 @@ package org.openmrs.module.appframework.repository;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
-import org.openmrs.api.db.hibernate.DbSessionFactory;  
+import org.openmrs.api.db.hibernate.DbSessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.module.appframework.domain.ComponentState;
 import org.openmrs.module.appframework.domain.ComponentType;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Repository
 public class AllComponentsState {
@@ -52,5 +56,16 @@ public class AllComponentsState {
         criteria.add(Restrictions.eq("componentId", componentId));
         criteria.add(Restrictions.eq("componentType", type));
         return (ComponentState) criteria.uniqueResult();
+    }
+
+    public Map<String, ComponentState> getComponentStatesFromDB(ComponentType type) {
+        Criteria criteria = sessionFactory.getCurrentSession().createCriteria(ComponentState.class);
+        criteria.add(Restrictions.eq("componentType", type));
+        List<ComponentState> rows = criteria.list();
+        Map<String, ComponentState> map = new HashMap<>(rows.size());
+        for (ComponentState cs : rows) {
+            map.put(cs.getComponentId(), cs);
+        }
+        return map;
     }
 }

--- a/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
@@ -312,7 +312,7 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 			try {
 				requireContext = getRequireExpressionContext(contextModel);
 			} catch (Exception e) {
-				log.error("Failed to pre-compute require expression context", e);
+				throw new IllegalStateException("Failed to pre-compute require expression context", e);
 			}
 		}
 
@@ -320,7 +320,7 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 			if ((candidate.getBelongsTo() == null
 			        || hasPrivilege(userContext, candidate.getBelongsTo().getRequiredPrivilege()))
 			        && hasPrivilege(userContext, candidate.getRequiredPrivilege())) {
-				if (contextModel == null || (requireContext != null && checkRequireExpressionWithContext(candidate, requireContext))) {
+				if (contextModel == null || checkRequireExpressionWithContext(candidate, requireContext)) {
 					extensions.add(candidate);
 				}
 			}
@@ -339,10 +339,7 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 			String script = precomputedContext + System.lineSeparator() + requireExpression;
 			return javascriptEngine.get().eval(script).equals(Boolean.TRUE);
 		} catch (Exception e) {
-			log.error("Failed to evaluate 'require' check for extension " + candidate.getId());
-			log.error("Expression: " + candidate.getRequire());
-			log.error(e);
-			return false;
+			throw new IllegalStateException("Failed to evaluate 'require' check for extension " + candidate.getId() + ", Expression: " + candidate.getRequire(), e);
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/appframework/service/AppFrameworkServiceImpl.java
@@ -146,10 +146,13 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 		// first just get all apps
 		List<AppDescriptor> appDescriptors = getAllApps();
 
+		// bulk-load all component states once before the loop
+		Map<String, ComponentState> componentStatesById = allComponentsState.getComponentStatesFromDB(ComponentType.APP);
+
 		// find out which ones are disabled
 		List<AppDescriptor> disabledAppDescriptors = new ArrayList<AppDescriptor>();
 		for (AppDescriptor appDescriptor : appDescriptors) {
-			if (disabledByComponentState(appDescriptor) || disabledByFeatureToggle(appDescriptor)
+			if (disabledByComponentState(appDescriptor, componentStatesById) || disabledByFeatureToggle(appDescriptor)
 			        || disabledByAppFrameworkConfig(appDescriptor)) {
 				disabledAppDescriptors.add(appDescriptor);
 			}
@@ -160,8 +163,8 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 		return appDescriptors;
 	}
 
-	private boolean disabledByComponentState(AppDescriptor appDescriptor) {
-		ComponentState componentState = allComponentsState.getComponentState(appDescriptor.getId(), ComponentType.APP);
+	private boolean disabledByComponentState(AppDescriptor appDescriptor, Map<String, ComponentState> componentStatesById) {
+		ComponentState componentState = componentStatesById.get(appDescriptor.getId());
 		return componentState != null && !componentState.getEnabled();
 	}
 
@@ -303,17 +306,44 @@ public class AppFrameworkServiceImpl extends BaseOpenmrsService implements AppFr
 		List<Extension> extensions = new ArrayList<Extension>();
 		UserContext userContext = Context.getUserContext();
 
+		// pre-compute the JS context string once for all extensions in this call
+		String requireContext = null;
+		if (contextModel != null) {
+			try {
+				requireContext = getRequireExpressionContext(contextModel);
+			} catch (Exception e) {
+				log.error("Failed to pre-compute require expression context", e);
+			}
+		}
+
 		for (Extension candidate : getAllEnabledExtensions(extensionPointId)) {
 			if ((candidate.getBelongsTo() == null
 			        || hasPrivilege(userContext, candidate.getBelongsTo().getRequiredPrivilege()))
 			        && hasPrivilege(userContext, candidate.getRequiredPrivilege())) {
-				if (contextModel == null || checkRequireExpression(candidate, contextModel)) {
+				if (contextModel == null || (requireContext != null && checkRequireExpressionWithContext(candidate, requireContext))) {
 					extensions.add(candidate);
 				}
 			}
 		}
 
 		return extensions;
+	}
+
+	private boolean checkRequireExpressionWithContext(Requireable candidate, String precomputedContext) {
+		String requireExpression = candidate.getRequire();
+		if (StringUtils.isBlank(requireExpression)) {
+			return true;
+		}
+		try {
+			requireExpression = StringEscapeUtils.unescapeHtml4(requireExpression);
+			String script = precomputedContext + System.lineSeparator() + requireExpression;
+			return javascriptEngine.get().eval(script).equals(Boolean.TRUE);
+		} catch (Exception e) {
+			log.error("Failed to evaluate 'require' check for extension " + candidate.getId());
+			log.error("Expression: " + candidate.getRequire());
+			log.error(e);
+			return false;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This PR has 2 perf improvements to the `getAllEnabledApps()` function:
- caches the content of the `feature_toggles.properties` file and uses the cache version if the file is not modified.
  - We can even remove the file modification check if users are expected to restart the server for changes in `feature_toggles.properties` to take effect.
- improves the `ComponentState` check in the DB for each app component by bulk loading the component stats for all apps

On PIH's zl-ci, this reduces O2 page load time by about 1s.